### PR TITLE
fix typo

### DIFF
--- a/RNN_project.ipynb
+++ b/RNN_project.ipynb
@@ -687,8 +687,8 @@
    },
    "outputs": [],
    "source": [
-    "### TODO: implement window_transform_series in my_answers.py\n",
-    "from my_answers import window_transform_series"
+    "### TODO: implement window_transform_text in my_answers.py\n",
+    "from my_answers import window_transform_text"
    ]
   },
   {


### PR DESCRIPTION
__WHY__:
I notice that window_transform_series imported twice.
Also, description cell contains 'window_transform_text' not a 'window_transform_series':  

> is used remember to copy your completed function into the script *my_answers.py* function titled *window_transform_text* before submitting your project)

Is this a typo?
But this project is great! I really like it, thanks!

__WHAT__:
I changed import  in second part from 'window_transform_series' to 'window_transform_text'